### PR TITLE
add .gitattributes for display of C#

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*css linguist-language= C#


### PR DESCRIPTION
Github indexes HTML as your repo main language instead of C# so by adding this it allows github recognize C# as the core language